### PR TITLE
Fix Clang-Format CI Pushing to Read Only Queue (#82)

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
           git config --local user.name "mmcesim-bot"
           git commit -am"Apply Clang-Format" || echo "Clang-Format already satisfied."
       - name: Push Changes
-        if: github.repository_owner == 'mmcesim'
+        if: github.repository_owner == 'mmcesim' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/')
         uses: ad-m/github-push-action@master
         with:
           branch: ${{ github.ref }}


### PR DESCRIPTION
Add additional pattern check when `git push`.