### PR TITLE
Paths Sorting According to Number of Jumps in Channel Graph (#68)

### DIFF
--- a/include/export/channel_graph.h
+++ b/include/export/channel_graph.h
@@ -72,6 +72,13 @@ class Channel_Graph {
     void _formPaths(const std::vector<size_t>& path);
 
     /**
+     * @brief Sort paths.
+     *
+     * @details This sorts the paths based on the jumps (sizes) of the paths (from short to long).
+     */
+    void _sortPaths();
+
+    /**
      * @brief Validate paths.
      *
      * @details This removes all paths that does not terminate in the Rx.

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -337,7 +337,8 @@ void Export::_generateChannels() {
     _log.flush();
     for (unsigned i = 0; i != _config["channels"].size(); ++i) {
         auto&& ch = _config["channels"][i];
-        _log.info() << "(Channel " << i << ") from: " << _channel_graph.from[i] << ", to: " << _channel_graph.to[i] << std::endl;
+        _log.info() << "(Channel " << i << ") from: " << _channel_graph.from[i] << ", to: " << _channel_graph.to[i]
+                    << std::endl;
         if (_channel_graph.from[i] > _channel_graph.nodes.size()) {
             std::string err =
                 fmt::format("Unknown 'from' node '{}' in channel '{}'!", _asStr(ch["from"]), _asStr(ch["id"]));

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -337,7 +337,7 @@ void Export::_generateChannels() {
     _log.flush();
     for (unsigned i = 0; i != _config["channels"].size(); ++i) {
         auto&& ch = _config["channels"][i];
-        _log.info() << "from: " << _channel_graph.from[i] << ", to: " << _channel_graph.to[i] << std::endl;
+        _log.info() << "(Channel " << i << ") from: " << _channel_graph.from[i] << ", to: " << _channel_graph.to[i] << std::endl;
         if (_channel_graph.from[i] > _channel_graph.nodes.size()) {
             std::string err =
                 fmt::format("Unknown 'from' node '{}' in channel '{}'!", _asStr(ch["from"]), _asStr(ch["id"]));
@@ -684,8 +684,8 @@ void Export::_estimation(const Macro& macro, int job_cnt) {
         Alg alg(estimation_str, macro, job_cnt);
         alg.write(_f(), _langStr());
     }
-    _log.info() << "====== Start of Estimation =====\n"
-                << estimation_str << "\n[INFO] ======= End of Estimation ======" << std::endl;
+    _log.info() << "===== Start of Estimation ====\n"
+                << estimation_str << "\n[INFO] ====== End of Estimation =====" << std::endl;
 }
 
 void Export::_reporting() {

--- a/src/export/channel_graph.cpp
+++ b/src/export/channel_graph.cpp
@@ -57,6 +57,7 @@ bool Channel_Graph::arrange() {
         _log.err() << "There are loops in the cascaded channel." << std::endl;
         return false;
     }
+    _sortPaths();
     size_t cnt = 0;
     paths_num_acc.reserve(paths.size());
     for (size_t i = 0; i != paths.size(); ++i) {
@@ -87,6 +88,13 @@ void Channel_Graph::_formPaths(const std::vector<size_t>& path) {
             }
         }
     }
+}
+
+void Channel_Graph::_sortPaths() {
+    std::sort(paths.begin(), paths.end(), [this](const auto& a, const auto& b) { return a.size() < b.size(); });
+    _log.info() << "Sorted Path Lengths:";
+    for (auto&& path : paths) _log.write() << ' ' << path.size();
+    _log.write() << std::endl;
 }
 
 void Channel_Graph::_validatePaths() {

--- a/test/single_RIS.sim
+++ b/test/single_RIS.sim
@@ -56,6 +56,10 @@ channels:
     from: UE
     to: RIS
     sparsity: 3
+  - id: H_direct
+    from: UE
+    to: BS
+    sparsity: 2
 sounding:
   variables:
     received: "y"


### PR DESCRIPTION
This is quite easy now. But there should still be a script to handle the task-oriented scheme according to the `` `CHS[<index>].JUMPS_NUM` `` or `` `CHS[<index>].SIZE` `` macro.